### PR TITLE
Prevent TranscriptionServer from crashing when speech_client is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package can be installed by adding `:ex_google_stt` to your list of dependen
 ```elixir
 def deps do
   [
-    {:ex_google_stt, "~> 0.4.2"}
+    {:ex_google_stt, "~> 0.4.3"}
   ]
 end
 ```

--- a/lib/transcription_server.ex
+++ b/lib/transcription_server.ex
@@ -126,9 +126,15 @@ defmodule ExGoogleSTT.TranscriptionServer do
   @impl GenServer
   # The difference between cancel and end is that this one kills the speech client immediately
   def handle_call(:cancel_stream, _from, state) do
-    :ok = GrpcSpeechClient.cancel_stream(state.speech_client)
-    :ok = GrpcSpeechClient.stop(state.speech_client)
-    {:reply, :ok, %{state | stream_state: :closed, speech_client: nil}}
+    case state.stream_state do
+      :open ->
+        :ok = GrpcSpeechClient.cancel_stream(state.speech_client)
+        :ok = GrpcSpeechClient.stop(state.speech_client)
+        {:reply, :ok, %{state | stream_state: :closed, speech_client: nil}}
+
+      :closed ->
+        {:reply, :ok, state}
+    end
   end
 
   @impl GenServer

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExGoogleSTT.MixProject do
   use Mix.Project
 
-  @version "0.4.2"
+  @version "0.4.3"
   @github_url "https://github.com/luiz-pereira/ex_google_stt"
 
   def project do

--- a/test/transcription_server_test.exs
+++ b/test/transcription_server_test.exs
@@ -304,4 +304,13 @@ defmodule ExGoogleSTT.TranscriptionServerTest do
       end
     end
   end
+
+  describe "cancel_stream/1" do
+    test "does not crash when speech_client is not alive" do
+      {:ok, server_pid} = TranscriptionServer.start_link(target: self())
+
+      assert TranscriptionServer.cancel_stream(server_pid) == :ok
+      assert :sys.get_state(server_pid).stream_state == :closed
+    end
+  end
 end


### PR DESCRIPTION
Calling `GrpcSpeechClient.cancel_stream(nil)` crashes the process, so we can check stream_state before the `send`.