### PR TITLE
Close stream when speech client has timed out

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The package can be installed by adding `:ex_google_stt` to your list of dependen
 ```elixir
 def deps do
   [
-    {:ex_google_stt, "~> 0.4.3"}
+    {:ex_google_stt, "~> 0.4.4"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExGoogleSTT.MixProject do
   use Mix.Project
 
-  @version "0.4.3"
+  @version "0.4.4"
   @github_url "https://github.com/luiz-pereira/ex_google_stt"
 
   def project do


### PR DESCRIPTION
Audio requests to the transcription server will not get replies after an "aborted" `%GRPC.RPCError{status: 10}` error has been received by the speech client. Closing the stream allows the transcription server to restart the speech client if new requests are received after that.