### PR TITLE
Update interface for decoding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ When starting the `TranscriptionServer`, you can define a few configs:
 - interim_results - a boolean to enable interim results, defaults to false
 - recognizer - a string representing the recognizer to use, defaults to use the recognizer from the config
 - model - a string representing the model to use, defaults to "latest_long". Be careful, changing to 'short' may have unintended consequences
+- explicit_decoding_config - a struct with audio decoding parameters
 ```
 
 Note that apart from the `interim_results` these configurations are better off set-up in the reconizer directly, so that you can control it without deploying any code.
@@ -104,6 +105,32 @@ The library allows you define other response handling functions and even ditch t
 
 
 ## Notes
+
+### Decoding
+
+If you are not relying on auto decoding, you can specify the custom encoding
+parameters of your audio stream.
+
+```elixir
+defmodule MyModule.Transcribing do
+  use GenServer
+
+  alias ExGoogleSTT.TranscriptionServer
+  alias Google.Cloud.Speech.V2.ExplicitDecodingConfig
+
+  def init(_opts) do
+    {:ok, transcription_server} =
+      TranscriptionServer.start_link(
+        target: self(),
+        interim_results: true,
+        explicit_decoding_config: %ExplicitDecodingConfig{
+          encoding: :LINEAR16,
+          sample_rate_hertz: 16000,
+          audio_channel_count: 1
+        }
+      )
+  end
+```
 
 ### Infinite stream
 Google's STT V2 knows when a sentence finishes, as long as there's some silence after it. When that happens, it'll return the transcription without ending the stream.

--- a/lib/transcription_server.ex
+++ b/lib/transcription_server.ex
@@ -213,9 +213,14 @@ defmodule ExGoogleSTT.TranscriptionServer do
     |> Map.put(:config, recognition_config)
   end
 
-  defp cast_decoding_config(recognition_config, %{decoding_config: decoding_config}) do
+  defp cast_decoding_config(recognition_config, %{auto_decoding_config: auto_decoding_config}) do
     recognition_config
-    |> Map.put(:decoding_config, decoding_config)
+    |> Map.put(:decoding_config, {:auto_decoding_config, auto_decoding_config})
+  end
+
+  defp cast_decoding_config(recognition_config, %{explicit_decoding_config: explicit_decoding_config}) do
+    recognition_config
+    |> Map.put(:decoding_config, {:explicit_decoding_config, explicit_decoding_config})
   end
 
   defp cast_decoding_config(recognition_config, _), do: recognition_config

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExGoogleSTT.MixProject do
   use Mix.Project
 
-  @version "0.4.5"
+  @version "0.5.0"
   @github_url "https://github.com/luiz-pereira/ex_google_stt"
 
   def project do


### PR DESCRIPTION
While not strictly necessary to pass decoding options, this PR is a suggestion to change the interface for the decoding config.

The `decoding_config` of `Google.Cloud.Speech.V2.RecognitionConfig` is `oneof` `AutoDetectDecodingConfig` or `ExplicitDecodingConfig`. To use that option with the `TranscriptionServer` today, it would require this code:

```elixir
TranscriptionServer.start_link(
  target: pid,
  decoding_config:
    {:explicit_decoding_config,
      %Google.Cloud.Speech.V2.ExplicitDecodingConfig{
        encoding: :LINEAR16,
        sample_rate_hertz: 16000,
        audio_channel_count: 1
      }}
)
```

However, this tripped me up and I think an interface that aligns with other SDK's would be
```elixir
TranscriptionServer.start_link(
  target: pid,
  explicit_decoding_config: %Google.Cloud.Speech.V2.ExplicitDecodingConfig{
    encoding: :LINEAR16,
    sample_rate_hertz: 16000,
    audio_channel_count: 1
  }
)
```

This would be a breaking change for anyone using the `decoding_config` option today, so I think it calls for a minor version bump to `0.5.0`.